### PR TITLE
Guess engine for pystac-client ItemSearch objects

### DIFF
--- a/tests/test_xarray_plugin.py
+++ b/tests/test_xarray_plugin.py
@@ -7,11 +7,9 @@ def test_xarray_open_dataset_can_guess_for_pystac_objects(simple_cog):
     assert ds
 
 
-def test_xarray_open_dataset_cannot_guess_for_pystac_client_objects(simple_search):
-    with pytest.raises(
-        ValueError, match="Consider explicitly selecting one of the installed engines"
-    ):
-        xarray.open_dataset(simple_search)
+def test_xarray_open_dataset_can_guess_for_pystac_client_searchs(simple_search):
+    ds = xarray.open_dataset(simple_search, assets=["blue", "green", "red"])
+    assert ds
 
 
 def test_xarray_open_dataset_with_drop_variables_raises(simple_search):

--- a/xpystac/core.py
+++ b/xpystac/core.py
@@ -4,14 +4,13 @@ from typing import List, Mapping, Union
 import pystac
 import xarray
 
-from xpystac.utils import _import_optional_dependency
+from xpystac.utils import _import_optional_dependency, _is_item_search
 
 
 @functools.singledispatch
 def to_xarray(obj, **kwargs) -> xarray.Dataset:
     """Given a pystac object return an xarray dataset"""
-    is_pystac_client_obj = hasattr(obj, "item_collection")
-    if is_pystac_client_obj:
+    if _is_item_search(obj):
         item_collection = obj.item_collection()
         return to_xarray(item_collection, **kwargs)
     raise TypeError

--- a/xpystac/utils.py
+++ b/xpystac/utils.py
@@ -1,4 +1,5 @@
 import importlib
+from typing import Any
 
 
 def _import_optional_dependency(name):
@@ -7,3 +8,12 @@ def _import_optional_dependency(name):
     except ImportError as e:
         raise ImportError(f"Missing optional dependency '{name}'") from e
     return module
+
+
+def _is_item_search(obj: Any):
+    """Whether object is an instance of class pystac_client.ItemSearch.
+
+    Note: this function does not import pystac_client in the interest of
+    speed.
+    """
+    return obj.__class__.__name__ == "ItemSearch"

--- a/xpystac/xarray_plugin.py
+++ b/xpystac/xarray_plugin.py
@@ -4,6 +4,7 @@ import pystac
 from xarray.backends import BackendEntrypoint
 
 from xpystac.core import to_xarray
+from xpystac.utils import _is_item_search
 
 
 class STACBackend(BackendEntrypoint):
@@ -22,4 +23,4 @@ class STACBackend(BackendEntrypoint):
     def guess_can_open(self, filename_or_obj: Any):
         return isinstance(
             filename_or_obj, (pystac.Asset, pystac.Item, pystac.ItemCollection)
-        )
+        ) or _is_item_search(filename_or_obj)


### PR DESCRIPTION
It looks like checking the class name takes on the order of 6µs so seems like a better approach than importing.

closes #27 